### PR TITLE
Implement list.clips

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,15 @@ list_id = 10
 list = client.lists[list_id] # Returns Kippt::ListItem
 ```
 
+Get single lists&rsquo;s clips:
+
+```ruby
+client = Kippt::Client.new(username: "vesan", token: "2544d6bfddf5893ec8617")
+list_id = 10
+list = Kippt::List.new({ id: list_id }, client)
+list.clips # Returns a Kippt::ClipCollection
+```
+
 
 #### Clips
 
@@ -156,7 +165,7 @@ clip.url = "http://github.com"
 clip.save #=> Returns boolean
 ```
 
-If you are missing required fields `#save` will return `false` and you can use 
+If you are missing required fields `#save` will return `false` and you can use
 `#errors` to get the error messages returned by the API.
 
 ```ruby
@@ -177,8 +186,8 @@ clip.destroy #=> true
 
 ### Debugging
 
-To get more information on what is going on under the covers, set `DEBUG=true` 
-as environment variable or pass `debug: true` in the Kippt::Client options hash 
+To get more information on what is going on under the covers, set `DEBUG=true`
+as environment variable or pass `debug: true` in the Kippt::Client options hash
 like:
 
 ```ruby

--- a/lib/kippt/list.rb
+++ b/lib/kippt/list.rb
@@ -21,6 +21,10 @@ class Kippt::List
     }
   end
 
+  def clips
+    Kippt::ClipCollection.new(client.get("lists/#{id}/clips").body, client)
+  end
+
   def follow
     response = client.post("#{resource_uri}relationship", :data => {:action => "follow"})
     raise Kippt::APIError.new("There was an error with the request: #{response.body["message"]}") unless response.success?

--- a/spec/kippt/list_spec.rb
+++ b/spec/kippt/list_spec.rb
@@ -34,7 +34,7 @@ describe Kippt::List do
   end
 
   describe "#clips" do
-    subject { Kippt::List.new({ id: 10 }, client).clips }
+    subject { Kippt::List.new({ "id" => 10 }, client).clips }
 
     it "returns the clips for the list" do
       stub_get("/lists/#{10}/clips").

--- a/spec/kippt/list_spec.rb
+++ b/spec/kippt/list_spec.rb
@@ -33,6 +33,16 @@ describe Kippt::List do
     end
   end
 
+  describe "#clips" do
+    subject { Kippt::List.new({ id: 10 }, client).clips }
+
+    it "returns the clips for the list" do
+      stub_get("/lists/#{10}/clips").
+        to_return(:status => 200, :body => fixture("clips.json"))
+      subject.should be_a Kippt::ClipCollection
+    end
+  end
+
   describe "#follow" do
     context "when request is successful" do
       let(:client) { Kippt::Client.new(valid_user_credentials) }


### PR DESCRIPTION
Hiya! I'm creating a quick & simple mobile app for getting "inbox zero" on Kippt using my iPad on the bus. I decided to use your gem, but getting the contents of inbox was kinda difficult. It is more than likely, that I just didn't understand the documentation. Sometimes I have the dumb. Anyhow, I made a fork and quickly created a new method for Kippt::List so that it'd work the way I assumed it to :) And here it is:

``` ruby
client = Kippt::Client.new(username: "vesan", token: "2544d6bfddf5893ec8617")
list_id = 10
list = Kippt::List.new({ id: list_id }, client)
list.clips # Returns a Kippt::ClipCollection
```

Disclaimer: I have never used RSpec, so I have **_no idea**_ how good the unit test is. I just cargo-culted it to fail and then pass. Pretty much what I did with the actual implementation (cargo-culted from clips.rb, tsihihii :smile:).

Cheers for the gem! :)

– ajk

PS. RSpec has some spectacular debug info for failing tests. Huh.
